### PR TITLE
added testing workflow file

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -5,6 +5,10 @@ on:
 
 jobs:
   cli:
+    env:
+      ZENODO_SANDBOX_ACCESS_TOKEN: ${{ secrets.ZENODO_SANDBOX_ACCESS_TOKEN }}
+      RECORD_ID: hello
+  
     runs-on: ubuntu-latest
     steps:
       - name: get a copy of the repo contents
@@ -23,9 +27,6 @@ jobs:
         run: mkdir testing && cd testing
 
       - name: test creating a new draft deposition in a new collection on zenodo sandbox
-        env:
-          ZENODO_SANDBOX_ACCESS_TOKEN: ${{ secrets.ZENODO_SANDBOX_ACCESS_TOKEN }}
-          RECORD_ID: hello
         run: RECORD_ID=$(zenodraft --sandbox deposition create in-new-collection)
 
       - name: test env vars

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -71,5 +71,5 @@ jobs:
           RECORD_ID: ${{ steps.get_record_id.outputs.record_id }}
           ZENODO_SANDBOX_ACCESS_TOKEN: ${{ secrets.ZENODO_SANDBOX_ACCESS_TOKEN }}
         run: |
-          echo "{"creators":[{"affiliation":"Netherlands eScience Center","name":"Spaaks, Jurriaan H.","orcid":"0000-0002-7064-4069"}],"description":"Auto-generated draft deposition for CI testing of zenodraft's CLI","keywords":["zenodo","cli"],"license":{"id":"Apache-2.0"},"title":"Auto-generated deposition for testing purposes"}" > .zenodo.json
+          echo "{\"creators\":[{\"affiliation\":\"Netherlands eScience Center\",\"name\":\"Spaaks, Jurriaan H.\",\"orcid\":\"0000-0002-7064-4069\"}],\"description\":\"Auto-generated draft deposition for CI testing of zenodraft's CLI\",\"keywords\":[\"zenodo\",\"cli\"],\"license\":{\"id\":\"Apache-2.0\"},\"title\":\"Auto-generated deposition for testing purposes\"}" > .zenodo.json
           zenodraft --sandbox metadata update $RECORD_ID .zenodo.json

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -14,7 +14,7 @@ jobs:
       - name: generate a distributable tarball
         run: npm run all
       - name: install the cli from the tarball
-        run: npm install -g zenodraft-*.tgz
+        run: sudo npm install -g zenodraft-*.tgz
       - name: create a new directory to do the testing in
         run: mkdir testing && cd testing
       # - name: 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -10,20 +10,25 @@ jobs:
         uses: actions/checkout@v2
 
 
+
       - name: install the project's dependencies
         run: npm install
+
 
 
       - name: generate a distributable tarball
         run: npm run all
 
 
+
       - name: install the cli from the tarball
         run: sudo npm install -g zenodraft-*.tgz
 
 
+
       - name: create a new directory to do the testing in
         run: mkdir testing && cd testing
+
 
 
       - name: test creating a new draft deposition in a new collection on zenodo sandbox
@@ -35,11 +40,25 @@ jobs:
           echo "::set-output name=record_id::$RECORD_ID"
 
 
+
       - name: test showing the complete details for the draft deposition
+        id: get_concept_record_id
         env:
           RECORD_ID: ${{ steps.get_record_id.outputs.record_id }}
           ZENODO_SANDBOX_ACCESS_TOKEN: ${{ secrets.ZENODO_SANDBOX_ACCESS_TOKEN }}
-        run: zenodraft --sandbox deposition show details $RECORD_ID
+        run: |
+          zenodraft --sandbox deposition show details $RECORD_ID > deposition.json
+          CONCEPT_RECORD_ID=$(cat deposition.json | jq '.conceptrecid' --raw-output)
+          echo "::set-output name=concept_record_id::$CONCEPT_RECORD_ID"
+
+
+
+      - name: test showing the id of the latest draft in the newly created collection
+        env:
+          CONCEPT_RECORD_ID: ${{ steps.get_concept_record_id.outputs.concept_record_id }}
+          ZENODO_SANDBOX_ACCESS_TOKEN: ${{ secrets.ZENODO_SANDBOX_ACCESS_TOKEN }}
+        run: zenodraft --sandbox deposition show latest $CONCEPT_RECORD_ID
+
 
 
       - name: test showing the prereserved doi for the draft deposition
@@ -47,6 +66,7 @@ jobs:
           RECORD_ID: ${{ steps.get_record_id.outputs.record_id }}
           ZENODO_SANDBOX_ACCESS_TOKEN: ${{ secrets.ZENODO_SANDBOX_ACCESS_TOKEN }}
         run: zenodraft --sandbox deposition show prereserved $RECORD_ID
+
 
 
       - name: test adding a file to the draft deposition
@@ -58,12 +78,14 @@ jobs:
           zenodraft --sandbox file add $RECORD_ID thefile.txt
 
 
+
       - name: test removing a file from the draft deposition
         env:
           RECORD_ID: ${{ steps.get_record_id.outputs.record_id }}
           ZENODO_SANDBOX_ACCESS_TOKEN: ${{ secrets.ZENODO_SANDBOX_ACCESS_TOKEN }}
         run: |
           zenodraft --sandbox file delete $RECORD_ID thefile.txt
+
 
 
       - name: test updating the deposition metadata with information from a local file
@@ -75,8 +97,17 @@ jobs:
           zenodraft --sandbox metadata update $RECORD_ID .zenodo.json
 
 
+
       - name: test clearing the deposition metadata
         env:
           RECORD_ID: ${{ steps.get_record_id.outputs.record_id }}
           ZENODO_SANDBOX_ACCESS_TOKEN: ${{ secrets.ZENODO_SANDBOX_ACCESS_TOKEN }}
         run: zenodraft --sandbox metadata clear $RECORD_ID
+
+
+
+      - name: test deleting a draft deposition
+        env:
+          RECORD_ID: ${{ steps.get_record_id.outputs.record_id }}
+          ZENODO_SANDBOX_ACCESS_TOKEN: ${{ secrets.ZENODO_SANDBOX_ACCESS_TOKEN }}
+        run: zenodraft --sandbox deposition delete $RECORD_ID

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -73,3 +73,10 @@ jobs:
         run: |
           echo "{\"creators\":[{\"affiliation\":\"Netherlands eScience Center\",\"name\":\"Spaaks, Jurriaan H.\",\"orcid\":\"0000-0002-7064-4069\"}],\"description\":\"Auto-generated draft deposition for CI testing of zenodraft's CLI\",\"keywords\":[\"zenodo\",\"cli\"],\"license\":{\"id\":\"Apache-2.0\"},\"title\":\"Auto-generated deposition for testing purposes\"}" > .zenodo.json
           zenodraft --sandbox metadata update $RECORD_ID .zenodo.json
+
+
+      - name: test clearing the deposition metadata
+        env:
+          RECORD_ID: ${{ steps.get_record_id.outputs.record_id }}
+          ZENODO_SANDBOX_ACCESS_TOKEN: ${{ secrets.ZENODO_SANDBOX_ACCESS_TOKEN }}
+        run: zenodraft --sandbox metadata clear $RECORD_ID

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -28,6 +28,9 @@ jobs:
 
       - name: test creating a new draft deposition in a new collection on zenodo sandbox
         run: RECORD_ID=$(zenodraft --sandbox deposition create in-new-collection)
+        
+      - name: test echo
+        run: echo $RECORD_ID
 
 #       - name: test env vars
 #         run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -6,8 +6,6 @@ on:
 jobs:
   cli:
     runs-on: ubuntu-latest
-    env:
-      ZENODO_SANDBOX_ACCESS_TOKEN: ${{ secrets.ZENODO_SANDBOX_ACCESS_TOKEN }}
     steps:
       - name: get a copy of the repo contents
         uses: actions/checkout@v2
@@ -26,6 +24,8 @@ jobs:
 
       - name: test creating a new draft deposition in a new collection on zenodo sandbox
         id: get_record_id
+        env:
+          ZENODO_SANDBOX_ACCESS_TOKEN: ${{ secrets.ZENODO_SANDBOX_ACCESS_TOKEN }}
         run: |
           RECORD_ID=$(zenodraft --sandbox deposition create in-new-collection)
           echo "::set-output name=record_id::$RECORD_ID"
@@ -33,19 +33,22 @@ jobs:
       - name: test showing the complete details for the draft deposition
         env:
           RECORD_ID: ${{ steps.get_record_id.outputs.record_id }}
+          ZENODO_SANDBOX_ACCESS_TOKEN: ${{ secrets.ZENODO_SANDBOX_ACCESS_TOKEN }}
         run: zenodraft --sandbox deposition show details $RECORD_ID
 
       - name: test showing the prereserved doi for the draft deposition
         env:
           RECORD_ID: ${{ steps.get_record_id.outputs.record_id }}
+          ZENODO_SANDBOX_ACCESS_TOKEN: ${{ secrets.ZENODO_SANDBOX_ACCESS_TOKEN }}
         run: zenodraft --sandbox deposition show prereserved $RECORD_ID
 
       - name: test adding a file to the draft deposition
         env:
           RECORD_ID: ${{ steps.get_record_id.outputs.record_id }}
+          ZENODO_SANDBOX_ACCESS_TOKEN: ${{ secrets.ZENODO_SANDBOX_ACCESS_TOKEN }}
         run: |
           echo "these are the file contents" > thefile.txt
-          zenodraft --sandbox file add thefile.txt $RECORD_ID
+          zenodraft --sandbox file add $RECORD_ID thefile.txt
 
       # - name: 
       #   run: 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -29,21 +29,21 @@ jobs:
       - name: test creating a new draft deposition in a new collection on zenodo sandbox
         run: RECORD_ID=$(zenodraft --sandbox deposition create in-new-collection)
 
-      - name: test env vars
-        run: |
-          echo $RECORD_ID
-          echo ${RECORD_ID}
-          echo ${{RECORD_ID}}
-          echo ${{env.RECORD_ID}}
+#       - name: test env vars
+#         run: |
+#           echo $RECORD_ID
+#           echo ${RECORD_ID}
+#           echo ${{RECORD_ID}}
+#           echo ${{env.RECORD_ID}}
 
-      - name: show the complete details for the draft deposition
-        run: zenodraft --sandbox deposition show details ${RECORD_ID}
+#       - name: show the complete details for the draft deposition
+#         run: zenodraft --sandbox deposition show details ${RECORD_ID}
 
-      - name: show the deposition id for the draft deposition
-        run: zenodraft --sandbox deposition show latest ${RECORD_ID}
+#       - name: show the deposition id for the draft deposition
+#         run: zenodraft --sandbox deposition show latest ${RECORD_ID}
 
-      - name: show the prereserved doi for the draft deposition
-        run: zenodraft --sandbox deposition show prereserved ${RECORD_ID}
+#       - name: show the prereserved doi for the draft deposition
+#         run: zenodraft --sandbox deposition show prereserved ${RECORD_ID}
       # - name: 
       #   run: 
       # - name: 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -33,21 +33,20 @@ jobs:
       - name: test echo
         run: echo "${{ steps.get_record_id.outputs.record_id }}"
 
-#       - name: test env vars
-#         run: |
-#           echo $RECORD_ID
-#           echo ${RECORD_ID}
-#           echo ${{RECORD_ID}}
-#           echo ${{env.RECORD_ID}}
+      - name: show the complete details for the draft deposition
+        env:
+          RECORD_ID: ${{ steps.get_record_id.outputs.record_id }}
+        run: zenodraft --sandbox deposition show details $RECORD_ID
 
-#       - name: show the complete details for the draft deposition
-#         run: zenodraft --sandbox deposition show details ${RECORD_ID}
+      - name: show the deposition id for the draft deposition
+        env:
+          RECORD_ID: ${{ steps.get_record_id.outputs.record_id }}
+        run: zenodraft --sandbox deposition show latest ${RECORD_ID}
 
-#       - name: show the deposition id for the draft deposition
-#         run: zenodraft --sandbox deposition show latest ${RECORD_ID}
-
-#       - name: show the prereserved doi for the draft deposition
-#         run: zenodraft --sandbox deposition show prereserved ${RECORD_ID}
+      - name: show the prereserved doi for the draft deposition
+        env:
+          RECORD_ID: ${{ steps.get_record_id.outputs.record_id }}
+        run: zenodraft --sandbox deposition show prereserved ${RECORD_ID}
       # - name: 
       #   run: 
       # - name: 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -9,24 +9,32 @@ jobs:
     steps:
       - name: get a copy of the repo contents
         uses: actions/checkout@v2
+
       - name: install the project's dependencies
         run: npm install
+
       - name: generate a distributable tarball
         run: npm run all
+
       - name: install the cli from the tarball
         run: sudo npm install -g zenodraft-*.tgz
+
       - name: create a new directory to do the testing in
         run: mkdir testing && cd testing
+
       - name: test creating a new draft deposition in a new collection on zenodo sandbox
         env:
           ZENODO_SANDBOX_ACCESS_TOKEN: ${{ secrets.ZENODO_SANDBOX_ACCESS_TOKEN }}
-        run: zenodraft --sandbox --verbose deposition create in-new-collection
-      # - name: 
-      #   run: 
-      # - name: 
-      #   run: 
-      # - name: 
-      #   run: 
+        run: RECORD_ID=zenodraft --sandbox deposition create in-new-collection
+
+      - name: show the complete details for the draft deposition
+        run: zenodraft --sandbox deposition show details ${RECORD_ID}
+
+      - name: show the deposition id for the draft deposition
+        run: zenodraft --sandbox deposition show latest ${RECORD_ID}
+
+      - name: show the prereserved doi for the draft deposition
+        run: zenodraft --sandbox deposition show prereserved ${RECORD_ID}
       # - name: 
       #   run: 
       # - name: 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -43,7 +43,7 @@ jobs:
       - name: test adding a file to the draft deposition
         env:
           RECORD_ID: ${{ steps.get_record_id.outputs.record_id }}
-        run:
+        run: |
           echo "these are the file contents" > thefile.txt
           zenodraft --sandbox file add thefile.txt $RECORD_ID
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -5,11 +5,9 @@ on:
 
 jobs:
   cli:
+    runs-on: ubuntu-latest
     env:
       ZENODO_SANDBOX_ACCESS_TOKEN: ${{ secrets.ZENODO_SANDBOX_ACCESS_TOKEN }}
-      RECORD_ID: hello
-  
-    runs-on: ubuntu-latest
     steps:
       - name: get a copy of the repo contents
         uses: actions/checkout@v2
@@ -27,10 +25,13 @@ jobs:
         run: mkdir testing && cd testing
 
       - name: test creating a new draft deposition in a new collection on zenodo sandbox
-        run: RECORD_ID=$(zenodraft --sandbox deposition create in-new-collection)
+        id: get_record_id
+        run: |
+          RECORD_ID=$(zenodraft --sandbox deposition create in-new-collection)
+          echo "::set-output name=record_id::$RECORD_ID"
         
       - name: test echo
-        run: echo $RECORD_ID
+        run: echo "${{ steps.get_record_id.outputs.record_id }}"
 
 #       - name: test env vars
 #         run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -17,8 +17,10 @@ jobs:
         run: sudo npm install -g zenodraft-*.tgz
       - name: create a new directory to do the testing in
         run: mkdir testing && cd testing
-      # - name: 
-      #   run: 
+      - name: test creating a new draft deposition in a new collection on zenodo sandbox
+        env:
+          ZENODO_SANDBOX_ACCESS_TOKEN: ${{ secrets.ZENODO_SANDBOX_ACCESS_TOKEN }}
+        run: zenodraft --sandbox --verbose deposition create in-new-collection
       # - name: 
       #   run: 
       # - name: 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -65,20 +65,11 @@ jobs:
         run: |
           zenodraft --sandbox file delete $RECORD_ID thefile.txt
 
-      # - name: 
-      #   run: 
-      # - name: 
-      #   run: 
-      # - name: 
-      #   run: 
-      # - name: 
-      #   run: 
-      # - name: 
-      #   run: 
-      # - name: 
-      #   run: 
-      # - name: 
-      #   run: 
-      # - name: 
-      #   run: 
-      # 
+
+      - name: test updating the deposition metadata with information from a local file
+        env:
+          RECORD_ID: ${{ steps.get_record_id.outputs.record_id }}
+          ZENODO_SANDBOX_ACCESS_TOKEN: ${{ secrets.ZENODO_SANDBOX_ACCESS_TOKEN }}
+        run: |
+          echo "{"creators":[{"affiliation":"Netherlands eScience Center","name":"Spaaks, Jurriaan H.","orcid":"0000-0002-7064-4069"}],"description":"Auto-generated draft deposition for CI testing of zenodraft's CLI","keywords":["zenodo","cli"],"license":{"id":"Apache-2.0"},"title":"Auto-generated deposition for testing purposes"}" > .zenodo.json
+          zenodraft --sandbox metadata update $RECORD_ID .zenodo.json

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,0 +1,44 @@
+name: testing
+on:
+  pull_request:
+  push:
+
+jobs:
+  cli:
+    runs-on: ubuntu-latest
+    steps:
+      - name: get a copy of the repo contents
+        uses: actions/checkout@v2
+      - name: install the project's dependencies
+        run: npm install
+      - name: generate a distributable tarball
+        run: npm run all
+      - name: install the cli from the tarball
+        run: npm install -g zenodraft-*.tgz
+      - name: create a new directory to do the testing in
+        run: mkdir testing && cd testing
+      # - name: 
+      #   run: 
+      # - name: 
+      #   run: 
+      # - name: 
+      #   run: 
+      # - name: 
+      #   run: 
+      # - name: 
+      #   run: 
+      # - name: 
+      #   run: 
+      # - name: 
+      #   run: 
+      # - name: 
+      #   run: 
+      # - name: 
+      #   run: 
+      # - name: 
+      #   run: 
+      # - name: 
+      #   run: 
+      # - name: 
+      #   run: 
+      # 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -25,7 +25,7 @@ jobs:
       - name: test creating a new draft deposition in a new collection on zenodo sandbox
         env:
           ZENODO_SANDBOX_ACCESS_TOKEN: ${{ secrets.ZENODO_SANDBOX_ACCESS_TOKEN }}
-        run: RECORD_ID=zenodraft --sandbox deposition create in-new-collection
+        run: RECORD_ID=$(zenodraft --sandbox deposition create in-new-collection)
 
       - name: show the complete details for the draft deposition
         run: zenodraft --sandbox deposition show details ${RECORD_ID}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
 
 jobs:
-  cli:
+  live-sandbox-cli:
     runs-on: ubuntu-latest
     steps:
       - name: get a copy of the repo contents

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,7 +1,6 @@
 name: testing
 on:
   pull_request:
-  push:
 
 jobs:
   cli:
@@ -10,17 +9,22 @@ jobs:
       - name: get a copy of the repo contents
         uses: actions/checkout@v2
 
+
       - name: install the project's dependencies
         run: npm install
+
 
       - name: generate a distributable tarball
         run: npm run all
 
+
       - name: install the cli from the tarball
         run: sudo npm install -g zenodraft-*.tgz
 
+
       - name: create a new directory to do the testing in
         run: mkdir testing && cd testing
+
 
       - name: test creating a new draft deposition in a new collection on zenodo sandbox
         id: get_record_id
@@ -29,18 +33,21 @@ jobs:
         run: |
           RECORD_ID=$(zenodraft --sandbox deposition create in-new-collection)
           echo "::set-output name=record_id::$RECORD_ID"
-        
+
+
       - name: test showing the complete details for the draft deposition
         env:
           RECORD_ID: ${{ steps.get_record_id.outputs.record_id }}
           ZENODO_SANDBOX_ACCESS_TOKEN: ${{ secrets.ZENODO_SANDBOX_ACCESS_TOKEN }}
         run: zenodraft --sandbox deposition show details $RECORD_ID
 
+
       - name: test showing the prereserved doi for the draft deposition
         env:
           RECORD_ID: ${{ steps.get_record_id.outputs.record_id }}
           ZENODO_SANDBOX_ACCESS_TOKEN: ${{ secrets.ZENODO_SANDBOX_ACCESS_TOKEN }}
         run: zenodraft --sandbox deposition show prereserved $RECORD_ID
+
 
       - name: test adding a file to the draft deposition
         env:
@@ -49,6 +56,14 @@ jobs:
         run: |
           echo "these are the file contents" > thefile.txt
           zenodraft --sandbox file add $RECORD_ID thefile.txt
+
+
+      - name: test removing a file from the draft deposition
+        env:
+          RECORD_ID: ${{ steps.get_record_id.outputs.record_id }}
+          ZENODO_SANDBOX_ACCESS_TOKEN: ${{ secrets.ZENODO_SANDBOX_ACCESS_TOKEN }}
+        run: |
+          zenodraft --sandbox file delete $RECORD_ID thefile.txt
 
       # - name: 
       #   run: 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -27,6 +27,13 @@ jobs:
           ZENODO_SANDBOX_ACCESS_TOKEN: ${{ secrets.ZENODO_SANDBOX_ACCESS_TOKEN }}
         run: RECORD_ID=$(zenodraft --sandbox deposition create in-new-collection)
 
+      - name: test env vars
+        run: |
+          echo $RECORD_ID
+          echo ${RECORD_ID}
+          echo ${{RECORD_ID}}
+          echo ${{env.RECORD_ID}}
+
       - name: show the complete details for the draft deposition
         run: zenodraft --sandbox deposition show details ${RECORD_ID}
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -25,11 +25,12 @@ jobs:
       - name: test creating a new draft deposition in a new collection on zenodo sandbox
         env:
           ZENODO_SANDBOX_ACCESS_TOKEN: ${{ secrets.ZENODO_SANDBOX_ACCESS_TOKEN }}
+          RECORD_ID: hello
         run: RECORD_ID=$(zenodraft --sandbox deposition create in-new-collection)
 
       - name: test env vars
         run: |
-          #echo $RECORD_ID
+          echo $RECORD_ID
           echo ${RECORD_ID}
           echo ${{RECORD_ID}}
           echo ${{env.RECORD_ID}}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: test env vars
         run: |
-          echo $RECORD_ID
+          #echo $RECORD_ID
           echo ${RECORD_ID}
           echo ${{RECORD_ID}}
           echo ${{env.RECORD_ID}}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -30,23 +30,23 @@ jobs:
           RECORD_ID=$(zenodraft --sandbox deposition create in-new-collection)
           echo "::set-output name=record_id::$RECORD_ID"
         
-      - name: test echo
-        run: echo "${{ steps.get_record_id.outputs.record_id }}"
-
-      - name: show the complete details for the draft deposition
+      - name: test showing the complete details for the draft deposition
         env:
           RECORD_ID: ${{ steps.get_record_id.outputs.record_id }}
         run: zenodraft --sandbox deposition show details $RECORD_ID
 
-      - name: show the deposition id for the draft deposition
+      - name: test showing the prereserved doi for the draft deposition
         env:
           RECORD_ID: ${{ steps.get_record_id.outputs.record_id }}
-        run: zenodraft --sandbox deposition show latest ${RECORD_ID}
+        run: zenodraft --sandbox deposition show prereserved $RECORD_ID
 
-      - name: show the prereserved doi for the draft deposition
+      - name: test adding a file to the draft deposition
         env:
           RECORD_ID: ${{ steps.get_record_id.outputs.record_id }}
-        run: zenodraft --sandbox deposition show prereserved ${RECORD_ID}
+        run:
+          echo "these are the file contents" > thefile.txt
+          zenodraft --sandbox file add thefile.txt $RECORD_ID
+
       # - name: 
       #   run: 
       # - name: 


### PR DESCRIPTION
This PR adds a workflow file for testing the various cli commands as advertised in the README. Testing is done against live system Zenodo Sandbox. Testing of `zenodraft deposition publish` is skipped.