### PR TITLE
update affiliations and ORCID add software type

### DIFF
--- a/.zenodo.extras.json
+++ b/.zenodo.extras.json
@@ -2,9 +2,10 @@
     "access_right": "open",
     "contributors": [
         {
-            "affiliation": "amberbiology.com",
-            "name": "Lancaster, Alex",
-            "type": "Other"
+            "affiliation": "Amber Biology LLC",
+            "name": "Lancaster, Alexander K",
+            "type": "Other",
+            "orcid": "0000-0002-0002-9263"	    
         }
     ]
 }

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -20,6 +20,7 @@ license: Apache-2.0
 message: If you use this software, please cite it using these metadata.
 repository-code: https://github.com/zenodraft/zenodraft
 title: zenodraft
+type: software
 version: 0.13.3
 references:
   - authors:


### PR DESCRIPTION
Thanks for including me in the Zenodo citation.  I'm just tweaking my affiliation info and adding my ORCID.

Also I noticed that the sorting of the versions for the Zenodo record seems wrong:

https://zenodo.org/search?q=parent.id%3A5046392&f=allversions%3Atrue&l=list&p=1&s=10&sort=version

I would expect that 0.13.3 would be near the top rather than the old 0.12.0, then I saw that the record is being uploaded as "Other".  I'm guessing this is because you now generate `.zenodo.json` from`CITATION.cff` and I think the `type: software` is missing in `CITATION.cff`.  

This PR fixes that too - hopefully that might fix the ordering issue in the Zenodo record, I suspect it might sort correctly if all records are of the same type.
